### PR TITLE
deps: unmaintained `dotenv_codegen` -> `dotenvy_macro`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,29 +177,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
-name = "dotenv"
-version = "0.15.0"
+name = "dotenvy"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
-name = "dotenv_codegen"
-version = "0.15.0"
+name = "dotenvy_macro"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56966279c10e4f8ee8c22123a15ed74e7c8150b658b26c619c53f4a56eb4a8aa"
+checksum = "cb0235d912a8c749f4e0c9f18ca253b4c28cfefc1d2518096016d6e3230b6424"
 dependencies = [
- "dotenv_codegen_implementation",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "dotenv_codegen_implementation"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e737a3522cd45f6adc19b644ce43ef53e1e9045f2d2de425c1f468abd4cf33"
-dependencies = [
- "dotenv",
- "proc-macro-hack",
+ "dotenvy",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -292,7 +281,7 @@ dependencies = [
  "anyhow",
  "av-data",
  "clap",
- "dotenv_codegen",
+ "dotenvy_macro",
  "itertools",
  "lexical-sort",
  "nom",
@@ -379,12 +368,6 @@ name = "path-clean"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.20+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ rust-version = "1.60"
 ansi_term = "0.12"
 anyhow = "1.0"
 clap = { version = "4.0.8", features = ["derive"] }
-dotenv_codegen = "0.15"
+dotenvy_macro = "0.15"
 itertools = "0.12"
 lexical-sort = "0.3"
 nom = "7.1.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,4 @@
-#[macro_use]
-extern crate dotenv_codegen;
+use dotenvy_macro::dotenv;
 
 mod input;
 mod output;


### PR DESCRIPTION
Hey, thanks for project.

Just a small contribution to switch from unmaintained `dotenv_codegen` to maintained `dotenvy_macro`.

---

If it was my project, I'd just use a simple wrapper script like this:

```sh
#!/bin/bash

export OUTPUT_PATH=/home/user/encodes

exec mp4batch "$@"
```

which avoids re-compiling and gets rid of the whole `dotenvy_macro` dep with its `syn`/`quote`/`proc-macro2` sub-deps, but that would be another story, right? 

Didn't want to interfere with your way of things :)
